### PR TITLE
feat: add facility to push Diagnostic messages up

### DIFF
--- a/lib/transformer.ts
+++ b/lib/transformer.ts
@@ -12,16 +12,22 @@ export abstract class Transformer<RootNode extends ts.Node> {
   /**
    * Performs the TypeScript transformation on the provided `RootNode`.
    *
-   * @param program the TypeScript `Program` that is being transformed.
-   * @param context the `TransformationContext` under which we are operating.
-   * @param node    the `RootNode` to be transformed.
+   * @param program  the TypeScript `Program` that is being transformed.
+   * @param context  the `TransformationContext` under which we are operating.
+   * @param node     the `RootNode` to be transformed.
+   * @param reporter the `Diagnostic` reporter.
    *
    * @returns the transformed `RootNode`.
    *
    * @internal
    */
-  public transform(program: ts.BuilderProgram, context: ts.TransformationContext, node: RootNode): RootNode {
-    return ts.visitNode(node, node => this.visit(program, context, node));
+  public transform(
+    program: ts.BuilderProgram,
+    context: ts.TransformationContext,
+    node: RootNode,
+    reporter: DiagnosticReporter,
+  ): RootNode {
+    return ts.visitNode(node, node => this.visit(program, context, node, reporter));
   }
 
   /**
@@ -34,8 +40,23 @@ export abstract class Transformer<RootNode extends ts.Node> {
    */
   protected abstract visitNode<T extends ts.Node>(node: T, env: TransformEnvironment): ts.VisitResult<T>;
 
-  private visit<T extends ts.Node>(program: ts.BuilderProgram, context: ts.TransformationContext, node: T): ts.VisitResult<T> {
-    let result = this.visitNode(node, { context, program });
+  private visit<T extends ts.Node>(
+    program: ts.BuilderProgram,
+    context: ts.TransformationContext,
+    node: T,
+    reporter: DiagnosticReporter,
+  ): ts.VisitResult<T> {
+    let result = this.visitNode(node, {
+      context, program,
+      reportDiagnostic: (node, category, code, messageText) => reporter({
+        category,
+        code,
+        file: node?.getSourceFile(),
+        messageText,
+        start: node?.getStart(),
+        length: node && node.getEnd() - node.getStart(),
+      })
+    });
 
     if (result === undefined) {
       return undefined;
@@ -45,7 +66,7 @@ export abstract class Transformer<RootNode extends ts.Node> {
       result = [result];
     }
 
-    result = result.map(newNode => ts.visitEachChild(newNode, toVisit => this.visit(program, context, toVisit), context))
+    result = result.map(newNode => ts.visitEachChild(newNode, toVisit => this.visit(program, context, toVisit, reporter), context))
       .filter(result => result != null)
       .map(result => Array.isArray(result) ? result : [result])
       .reduce((acc, newNode) => [...acc, newNode], []);
@@ -93,4 +114,26 @@ export interface TransformEnvironment {
    * The TypeScript `Program`, from which a `TypeChecker` can be obtained.
    */
   readonly program: ts.BuilderProgram;
+
+  /**
+   * A facility to report `Diagnostic` messages to the compiler.
+   *
+   * @param node        the `Node` the error is related to.
+   * @param category    the `DiagnosticCategory` for the message.
+   * @param code        the code for the diagnostic message.
+   * @param messageText the text for the message.
+   */
+  readonly reportDiagnostic: (
+    node: ts.Node | null,
+    category: ts.DiagnosticCategory,
+    code: number,
+    messageText: string
+  ) => void;
 }
+
+/**
+ * A function that reports `Diagnostic` entries to the `TypeScriptCompiler`.
+ *
+ * @param diag the `Diagnostic` to be reported.
+ */
+export type DiagnosticReporter = (diag: ts.Diagnostic) => void;

--- a/lib/typescript-compiler.ts
+++ b/lib/typescript-compiler.ts
@@ -81,7 +81,8 @@ export class TypeScriptCompiler {
   }
 
   private transformProgram(program: ts.BuilderProgram) {
-    return program.emit(
+    const additionalDiagnostics = new Array<ts.Diagnostic>();
+    const emitResult = program.emit(
       undefined,  // targetSourceFile
       undefined,  // writeFile
       undefined,  // cancellationToken
@@ -99,8 +100,14 @@ export class TypeScriptCompiler {
       },
     );
 
+    return {
+      ...emitResult,
+      diagnostics: [...emitResult.diagnostics, ...additionalDiagnostics]
+    };
+
     function toTransformerFactory<T extends ts.Bundle | ts.SourceFile>(transformer: Transformer<T>): ts.TransformerFactory<T> {
-      return context => node => transformer.transform(program, context, node);
+      return context =>
+        node => transformer.transform(program, context, node, additionalDiagnostics.push.bind(additionalDiagnostics));
     }
   }
 }


### PR DESCRIPTION
Working around the fact the TypeScript compiler API does not provide such a feature,
a reporter method is provided to allow transformers to push Diagnostic messages back
up, where they'll be mixed with the entries generated by TypeScript itself.